### PR TITLE
페이지 생성, 좋아요, 싫어요 API 구현

### DIFF
--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/_core/utils/ApiUtils.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/_core/utils/ApiUtils.java
@@ -1,0 +1,33 @@
+package com.kakao.techcampus.wekiki._core.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+public class ApiUtils {
+
+    public static <T> ApiResult<T> success(T response) {
+        return new ApiResult<>(true, response, null);
+    }
+
+    public static ApiResult<?> error(String message, HttpStatus status) {
+        return new ApiResult<>(false, null, new ApiError(message, status.value()));
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class ApiResult<T> {
+        private final boolean success;
+        private final T response;
+        private final ApiError error;
+    }
+
+
+    @Getter @Setter @AllArgsConstructor
+    public static class ApiError {
+        private final String message;
+        private final int status;
+    }
+}

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/history/History.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/history/History.java
@@ -28,10 +28,9 @@ public class History {
     private LocalDateTime created_at;
 
     @Builder
-    public History(Long id, GroupMember groupMember, Page page, Post post, String content, LocalDateTime created_at) {
+    public History(Long id, GroupMember groupMember, Post post, String content, LocalDateTime created_at) {
         this.id = id;
         this.groupMember = groupMember;
-        this.page = page;
         this.post = post;
         this.content = content;
         this.created_at = created_at;

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/Page.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/Page.java
@@ -38,4 +38,8 @@ public class Page {
         this.created_at = created_at;
         this.updated_at = updated_at;
     }
+
+    public void plusGoodCount(){
+        this.goodCount++;
+    }
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/Page.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/Page.java
@@ -42,4 +42,9 @@ public class Page {
     public void plusGoodCount(){
         this.goodCount++;
     }
+
+    public void plusBadCount(){
+        this.badCount++;
+    }
+
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/Page.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/Page.java
@@ -25,9 +25,10 @@ public class Page {
     private int badCount;
     private int viewCount;
     private LocalDateTime created_at;
+    private LocalDateTime updated_at;
 
     @Builder
-    public Page(Long id, Group group, String title, int goodCount, int badCount, int viewCount, LocalDateTime created_at) {
+    public Page(Long id, Group group, String title, int goodCount, int badCount, int viewCount, LocalDateTime created_at, LocalDateTime updated_at) {
         this.id = id;
         this.group = group;
         this.title = title;
@@ -35,5 +36,6 @@ public class Page {
         this.badCount = badCount;
         this.viewCount = viewCount;
         this.created_at = created_at;
+        this.updated_at = updated_at;
     }
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageJPARepository.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageJPARepository.java
@@ -1,0 +1,8 @@
+package com.kakao.techcampus.wekiki.page;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PageJPARepository extends JpaRepository<Page, Long> {
+
+
+}

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRequest.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRequest.java
@@ -18,5 +18,10 @@ public class PageRequest {
         private Long groupId;
     }
 
+    @Getter
+    @Setter
+    public static class hatePageDTO {
+        private Long groupId;
+    }
 
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRequest.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRequest.java
@@ -12,4 +12,11 @@ public class PageRequest {
         private Long groupId;
     }
 
+    @Getter
+    @Setter
+    public static class likePageDTO {
+        private Long groupId;
+    }
+
+
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRequest.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRequest.java
@@ -1,0 +1,15 @@
+package com.kakao.techcampus.wekiki.page;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class PageRequest {
+
+    @Getter
+    @Setter
+    public static class createPageDTO {
+        private String title;
+        private Long groupId;
+    }
+
+}

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageResponse.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageResponse.java
@@ -1,0 +1,20 @@
+package com.kakao.techcampus.wekiki.page;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class PageResponse {
+
+    @Getter @Setter
+    public static class createPageDTO{
+
+        Long pageId;
+        String title;
+
+        public createPageDTO(Page page){
+            this.pageId = page.getId();
+            this.title = page.getTitle();
+        }
+    }
+
+}

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageResponse.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageResponse.java
@@ -31,4 +31,18 @@ public class PageResponse {
         }
     }
 
+    @Getter @Setter
+    public static class hatePageDTO{
+
+        Long pageId;
+        String title;
+        int badCount;
+
+        public hatePageDTO(Page page){
+            this.pageId = page.getId();
+            this.title = page.getTitle();
+            this.badCount = page.getBadCount();
+        }
+    }
+
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageResponse.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageResponse.java
@@ -17,4 +17,18 @@ public class PageResponse {
         }
     }
 
+    @Getter @Setter
+    public static class likePageDTO{
+
+        Long pageId;
+        String title;
+        int goodCount;
+
+        public likePageDTO(Page page){
+            this.pageId = page.getId();
+            this.title = page.getTitle();
+            this.goodCount = page.getGoodCount();
+        }
+    }
+
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRestController.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRestController.java
@@ -57,9 +57,14 @@ public class PageRestController {
      */
 
     @PostMapping("/{pageid}/like")
-    public void likePage(@PathVariable Long pageid) {
+    public ResponseEntity<?> likePage(@PathVariable Long pageid , @RequestBody PageRequest.likePageDTO request) {
 
+        // TODO : JWT에서 userId 꺼내도록 수정
+        Long tempUserId = 1L;
 
+        PageResponse.likePageDTO response = pageService.likePage(pageid, request.getGroupId(), tempUserId);
+
+        return ResponseEntity.ok(ApiUtils.success(response));
     }
 
     /*

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRestController.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRestController.java
@@ -73,8 +73,14 @@ public class PageRestController {
      */
 
     @PostMapping("/{pageid}/hate")
-    public void hatePage(@PathVariable Long pageid) {
+    public ResponseEntity<?> hatePage(@PathVariable Long pageid , @RequestBody PageRequest.hatePageDTO request) {
 
+        // TODO : JWT에서 userId 꺼내도록 수정
+        Long tempUserId = 1L;
+
+        PageResponse.hatePageDTO response = pageService.hatePage(pageid, request.getGroupId(), tempUserId);
+
+        return ResponseEntity.ok(ApiUtils.success(response));
 
     }
 

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRestController.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRestController.java
@@ -1,0 +1,79 @@
+package com.kakao.techcampus.wekiki.page;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/page")
+@RequiredArgsConstructor
+public class PageRestController {
+
+    //private final PageService pageService;
+
+    /*
+     페이지 + 글 조회 기능
+
+     */
+
+    @GetMapping("/{pageid}")
+    public void getPage(@PathVariable Long pageid) {
+
+
+    }
+
+    /*
+     페이지 생성 기능
+
+     */
+
+    @PostMapping("/create")
+    public void createPage() {
+
+
+    }
+
+    /*
+     페이지 삭제 기능
+
+     */
+
+    @DeleteMapping("/{pageid}")
+    public void deletePage(@PathVariable Long pageid) {
+
+
+    }
+
+    /*
+     페이지 좋아요 기능
+
+     */
+
+    @PostMapping("/{pageid}/like")
+    public void likePage(@PathVariable Long pageid) {
+
+
+    }
+
+    /*
+     페이지 싫어요 기능
+
+     */
+
+    @PostMapping("/{pageid}/hate")
+    public void hatePage(@PathVariable Long pageid) {
+
+
+    }
+
+    /*
+     페이지 키워드 검색 기능
+
+     */
+
+    @GetMapping("/search")
+    public void searchPage(@RequestParam("keyword") String keyword) {
+
+
+    }
+}

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRestController.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageRestController.java
@@ -1,7 +1,9 @@
 package com.kakao.techcampus.wekiki.page;
 
 
+import com.kakao.techcampus.wekiki._core.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -9,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class PageRestController {
 
-    //private final PageService pageService;
+    private final PageService pageService;
 
     /*
      페이지 + 글 조회 기능
@@ -28,9 +30,14 @@ public class PageRestController {
      */
 
     @PostMapping("/create")
-    public void createPage() {
+    public ResponseEntity<?> createPage(@RequestBody PageRequest.createPageDTO request) {
 
+        // TODO : JWT에서 userId 꺼내도록 수정
+        Long tempUserId = 1L;
 
+        PageResponse.createPageDTO response = pageService.createPage(request.getTitle(), request.getGroupId(), tempUserId);
+
+        return ResponseEntity.ok(ApiUtils.success(response));
     }
 
     /*

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageService.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageService.java
@@ -59,4 +59,24 @@ public class PageService {
 
     }
 
+    @Transactional
+    public PageResponse.hatePageDTO hatePage(Long pageId , Long groupId, Long userId){
+
+        // 1. groupId랑 userId로 Group 객체, User 객체 가져오기 (없으면 Exception)
+
+        // 2. groupMember 존재하는지 확인 (없으면 Exception)
+
+        // 3. 해당 페이지 불러오기 (없으면 Exception)
+        Optional<Page> page = pageJPARepository.findById(pageId);
+
+        // 4. 페이지 goodCount 증가
+        page.get().plusBadCount();
+
+        // 5. 유저 경험치증가 or 유저 당일 페이지 좋아요 횟수 차감
+
+        // 6. return
+        return new PageResponse.hatePageDTO(page.get());
+
+    }
+
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageService.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageService.java
@@ -39,5 +39,24 @@ public class PageService {
         return new PageResponse.createPageDTO(savedPage);
     }
 
+    @Transactional
+    public PageResponse.likePageDTO likePage(Long pageId , Long groupId, Long userId){
+
+        // 1. groupId랑 userId로 Group 객체, User 객체 가져오기 (없으면 Exception)
+
+        // 2. groupMember 존재하는지 확인 (없으면 Exception)
+
+        // 3. 해당 페이지 불러오기 (없으면 Exception)
+        Optional<Page> page = pageJPARepository.findById(pageId);
+
+        // 4. 페이지 goodCount 증가
+        page.get().plusGoodCount();
+
+        // 5. 유저 경험치증가 or 유저 당일 페이지 좋아요 횟수 차감
+
+        // 6. return
+        return new PageResponse.likePageDTO(page.get());
+
+    }
 
 }

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageService.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/page/PageService.java
@@ -1,0 +1,43 @@
+package com.kakao.techcampus.wekiki.page;
+
+import com.kakao.techcampus.wekiki.group.Group;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class PageService {
+
+    private final PageJPARepository pageJPARepository;
+
+    @Transactional
+    public PageResponse.createPageDTO createPage(String title, Long groupId, Long userId){
+
+        // 1. groupId랑 userId로 Group 객체, User 객체 가져오기 (없으면 Exception)
+
+        // 2. groupMember 존재하는지 확인 (없으면 Exception)
+
+        // 3. Page 생성
+        Page newPage = Page.builder()
+                //.group(group)
+                .title(title)
+                .goodCount(0)
+                .badCount(0)
+                .viewCount(0)
+                .created_at(LocalDateTime.now())
+                .updated_at(LocalDateTime.now())
+                .build();
+
+        // 4. Page 저장
+        Page savedPage = pageJPARepository.save(newPage);
+
+        // 5. return
+        return new PageResponse.createPageDTO(savedPage);
+    }
+
+
+}

--- a/wekiki/src/main/java/com/kakao/techcampus/wekiki/report/Report.java
+++ b/wekiki/src/main/java/com/kakao/techcampus/wekiki/report/Report.java
@@ -2,6 +2,7 @@ package com.kakao.techcampus.wekiki.report;
 
 import com.kakao.techcampus.wekiki.group.member.GroupMember;
 import com.kakao.techcampus.wekiki.page.Page;
+import com.kakao.techcampus.wekiki.post.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,10 +25,10 @@ public class Report {
     private String content;
 
     @Builder
-    public Report(Long id, GroupMember groupMember, Page page, String content) {
+    public Report(Long id, GroupMember groupMember, Post post, String content) {
         this.id = id;
         this.groupMember = groupMember;
-        this.page = page;
+        this.post = post;
         this.content = content;
     }
 }


### PR DESCRIPTION
## ⭐Key Changes
1. 페이지 생성 API 구현
2. 페이지 좋아요 API 구현
3. 페이지 싫어요 API 구현

<br>

## 📌Issue
close #4 

<br>

## 👪To Reviewers
1. Member랑 Group쪽이 구현이 안된 상황이라 일단 페이지 생성,좋아요,싫어요 API에서 관련 부분은 주석처리로 자리만 만들어두고 나머지 부분만 구현하였습니다. (작동은 합니다)
2. 최근 변경된 페이지 조회하는 기능에서 사용할려고 Page 객체에 updated_at 추가하였습니다. 해당 페이지에 Post들이 생성 또는 수정하면 Page 객체에도 updated_at을 변경시켜서 최근 변경된 Page 조회시에 Page 테이블만 읽도록 구현할 예정입니다.

<br>

